### PR TITLE
Fixed a tiny syntax error.

### DIFF
--- a/OD_Colors.ahk
+++ b/OD_Colors.ahk
@@ -33,7 +33,7 @@
 ;///////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Class OD_Colors {
-    static OnMessageInit := OnMessage(0x002C, OD_Colors.MeasureItem)
+    static OnMessageInit := (OnMessage(0x002C, OD_Colors.MeasureItem))
     static ItemHeight := 0
     static Controls := Map()
 


### PR DESCRIPTION
Fixed a tiny syntax error:

```ahk
static OnMessageInit := OnMessage(0x002C, OD_Colors.MeasureItem)
```
Should be:
```ahk
static OnMessageInit := (OnMessage(0x002C, OD_Colors.MeasureItem))
```
